### PR TITLE
finelizedData returns tripletIds

### DIFF
--- a/docflow/docflow/ProcessResults.xaml.cs
+++ b/docflow/docflow/ProcessResults.xaml.cs
@@ -124,6 +124,7 @@ namespace docflow
                 }
 
                 finalizedData["ocr"] = ocrArray;
+                finalizedData["tripletIds"] = _data[0]["tripletIds"];
 
                 string jsonContent = JsonConvert.SerializeObject(finalizedData);
 


### PR DESCRIPTION
Added triplet ids in finalizedData to be returned back to server so ocr triplets can be successfully finalized.